### PR TITLE
Add random key eviction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,7 @@ enum Operation<K, V> {
     Add(K, V),
     Remove(K, V),
     Empty(K),
+    EmptyRandom(usize),
     Clear(K),
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -251,6 +251,23 @@ fn empty() {
 }
 
 #[test]
+fn empty_random() {
+    let (r, mut w) = evmap::new();
+    w.insert(1, "a");
+    w.insert(1, "b");
+    w.insert(2, "c");
+    w.empty_at_index(0);
+    w.refresh();
+
+    // should only have one value set left
+    assert_eq!(r.len(), 1);
+    // one of them must have gone away
+    assert!(
+        (!r.contains_key(&1) && r.contains_key(&2)) || (r.contains_key(&1) && !r.contains_key(&2))
+    );
+}
+
+#[test]
 fn empty_post_refresh() {
     let (r, mut w) = evmap::new();
     w.insert(1, "a");


### PR DESCRIPTION
Add support for rahashmap-style random eviction on `WriteHandle`.